### PR TITLE
Add update_while_panning option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     # Pin freetype to 2.5.5 to keep image tests consistent
     - CONDA_DEPENDENCIES="numpy matplotlib freetype=2.5.5 mock astropy"
-    - PIP_DEPENDENCIES="pytest-mpl fast-histogram coveralls pytest-cov"
+    - PIP_DEPENDENCIES="pytest-mpl fast-histogram codecov pytest-cov"
     - SETUP_XVFB=true
   matrix:
     - PYTHON_VERSION=2.7
@@ -27,4 +27,4 @@ script:
   - pytest mpl_scatter_density --mpl -p no:warnings --cov mpl_scatter_density
 
 after_success:
-  - coveralls
+  - codecov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 0.4 (unreleased)
 ----------------
 
-- No changes yet.
+- Added a keyword argument ``histogram2d_callable`` to optionally
+  specify the 2D histogram function to use. [#16]
+
+- Added a keyword argment ``compute_on_pan`` to set whether to
+  compute the scatter denstiy map while panning and zooming. [#16]
 
 0.3 (2017-10-29)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 0.4 (unreleased)
 ----------------
 
-- Added a keyword argument ``histogram2d_callable`` to optionally
+- Added a keyword argument ``histogram2d_func`` to optionally
   specify the 2D histogram function to use. [#16]
 
-- Added a keyword argment ``compute_on_pan`` to set whether to
+- Added a keyword argment ``update_while_panning`` to set whether to
   compute the scatter denstiy map while panning and zooming. [#16]
 
 0.3 (2017-10-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,6 @@
 0.4 (unreleased)
 ----------------
 
-- Added a keyword argument ``histogram2d_func`` to optionally
-  specify the 2D histogram function to use. [#16]
-
 - Added a keyword argment ``update_while_panning`` to set whether to
   compute the scatter denstiy map while panning and zooming. [#16]
 

--- a/mpl_scatter_density/fixed_data_density_helper.py
+++ b/mpl_scatter_density/fixed_data_density_helper.py
@@ -1,0 +1,129 @@
+from __future__ import division, print_function
+
+from math import log10
+
+import numpy as np
+
+from fast_histogram import histogram2d
+
+
+class FixedDataDensityHelper:
+
+    compute_when_pressed = True
+
+    def __init__(self, ax, x, y, c=None, downres_factor=4):
+
+        self._ax = ax
+        self._c = None
+        self._downres = False
+
+        if downres_factor < 1 or downres_factor % 1 != 0:
+            raise ValueError('downres_factor should be a strictly positive integer value')
+
+        self._downres_factor = downres_factor
+        self.set_xy(x, y)
+        self.set_c(c)
+
+    def downres(self):
+        self._downres = True
+
+    def upres(self):
+        self._downres = False
+
+    def set_xy(self, x, y):
+        self._x = x
+        self._y = y
+        self._x_log = None
+        self._y_log = None
+        self._x_log_sub = None
+        self._y_log_sub = None
+        step = self._downres_factor ** 2
+        self._x_sub = self._x[::step]
+        self._y_sub = self._y[::step]
+
+    def set_c(self, c):
+        self._c = c
+        step = self._downres_factor ** 2
+        if self._c is None:
+            self._c_sub = None
+        else:
+            self._c_sub = self._c[::step]
+
+    def _update_x_log(self):
+        step = self._downres_factor ** 2
+        with np.errstate(invalid='ignore'):
+            self._x_log = np.log10(self._x)
+        self._x_log_sub = self._x_log[::step]
+
+    def _update_y_log(self):
+        step = self._downres_factor ** 2
+        with np.errstate(invalid='ignore'):
+            self._y_log = np.log10(self._y)
+        self._y_log_sub = self._y_log[::step]
+
+    def __call__(self, bins=None, range=None):
+
+        ny, nx = bins
+        (ymin, ymax), (xmin, xmax) = range
+
+        xscale = self._ax.get_xscale()
+        yscale = self._ax.get_yscale()
+
+        if xscale == 'log':
+            xmin, xmax = log10(xmin), log10(xmax)
+            if self._x_log is None:
+                # We do this here insead of in set_xy to save time since in
+                # set_xy we don't know yet if the axes will be log or not.
+                self._update_x_log()
+            if self._downres:
+                x = self._x_log_sub
+            else:
+                x = self._x_log
+        elif xscale == 'linear':
+            if self._downres:
+                x = self._x_sub
+            else:
+                x = self._x
+        else:  # pragma: nocover
+            raise ValueError('Unexpected xscale: {0}'.format(xscale))
+
+        if yscale == 'log':
+            ymin, ymax = log10(ymin), log10(ymax)
+            if self._y_log is None:
+                # We do this here insead of in set_xy to save time since in
+                # set_xy we don't know yet if the axes will be log or not.
+                self._update_y_log()
+            if self._downres:
+                y = self._y_log_sub
+            else:
+                y = self._y_log
+        elif yscale == 'linear':
+            if self._downres:
+                y = self._y_sub
+            else:
+                y = self._y
+        else:  # pragma: nocover
+            raise ValueError('Unexpected xscale: {0}'.format(xscale))
+
+        if self._downres:
+            nx_sub = nx // self._downres_factor
+            ny_sub = ny // self._downres_factor
+            bins = (ny_sub, nx_sub)
+            weights = self._c_sub
+        else:
+            bins = (ny, nx)
+            weights = self._c
+
+        if weights is None:
+            array = histogram2d(y, x, bins=bins,
+                                range=((ymin, ymax), (xmin, xmax)))
+        else:
+            array = histogram2d(y, x, bins=bins, weights=weights,
+                                range=((ymin, ymax), (xmin, xmax)))
+            count = histogram2d(y, x, bins=bins,
+                                range=((ymin, ymax), (xmin, xmax)))
+
+            with np.errstate(invalid='ignore'):
+                array /= count
+
+        return array

--- a/mpl_scatter_density/generic_density_artist.py
+++ b/mpl_scatter_density/generic_density_artist.py
@@ -16,7 +16,12 @@ IDENTITY = IdentityTransform()
 
 class GenericDensityArtist(AxesImage):
     """
-    Matplotlib artist to make a density plot of (x, y) scatter data.
+    Matplotlib artist to make a density plot given a helper histogram function.
+
+    This is a more generic form of ``ScatterDensityArtist``. Here, we can
+    initialize the class with a histogram function that just takes bins and the
+    range of values, and returns a density array. This is useful for cases where
+    the data might be changing dynamically over time.
 
     Parameters
     ----------

--- a/mpl_scatter_density/generic_density_artist.py
+++ b/mpl_scatter_density/generic_density_artist.py
@@ -1,0 +1,203 @@
+from __future__ import division, print_function
+
+import numpy as np
+
+from matplotlib.image import AxesImage
+from matplotlib.transforms import (IdentityTransform, TransformedBbox,
+                                   BboxTransformFrom, Bbox)
+
+from .color import make_cmap
+
+__all__ = ['GenericDensityArtist']
+
+EMPTY_IMAGE = np.array([[np.nan]])
+IDENTITY = IdentityTransform()
+
+
+class GenericDensityArtist(AxesImage):
+    """
+    Matplotlib artist to make a density plot of (x, y) scatter data.
+
+    Parameters
+    ----------
+    ax : `matplotlib.axes.Axes`
+        The axes to plot the artist into.
+    dpi : int or `None`
+        The number of dots per inch to include in the density map. To use
+        the native resolution of the drawing device, set this to None.
+    cmap : `matplotlib.colors.Colormap`
+        The colormap to use for the density map.
+    color : str or tuple
+        The color to use for the density map. This can be any valid
+        Matplotlib color. If specified, this takes precedence over the
+        colormap.
+    alpha : float
+        Overall transparency of the density map.
+    norm : `matplotlib.colors.Normalize`
+        The normalization class for the density map.
+    vmin, vmax : float or func
+        The lower and upper levels used for scaling the density map. These can
+        optionally be functions that take the density array and returns a single
+        value (e.g. a function that returns the 5% percentile, or the minimum).
+        This is useful since when zooming in/out, the optimal limits change.
+    histogram2d_func : callable, optional
+        The function (or callable instance) to use for computing the 2D
+        histogram - this should take the arguments ``bins`` and ``range`` as
+        defined by :func:`~numpy.histogram2d` as well as a ``pressed`` keyword
+        argument that indicates whether the user is currently panning/zooming.
+    kwargs
+        Any additional keyword arguments are passed to AxesImage.
+    """
+
+    def __init__(self, ax, dpi=72, color=None, vmin=None, vmax=None, norm=None, histogram2d_func=None, update_while_panning=True, **kwargs):
+
+        super(GenericDensityArtist, self).__init__(ax, **kwargs)
+
+        self._histogram2d_func = histogram2d_func
+
+        self._pressed = False
+        self._density_vmin = np.nanmin
+        self._density_vmax = np.nanmax
+
+        self._ax = ax
+        self._ax.figure.canvas.mpl_connect('button_press_event', self.on_press)
+        self._ax.figure.canvas.mpl_connect('button_release_event', self.on_release)
+
+        self._update_while_panning = update_while_panning
+
+        self.set_dpi(dpi)
+
+        self.on_release()
+        self.set_array(EMPTY_IMAGE)
+
+        if color is not None:
+            self.set_color(color)
+
+        if norm is not None:
+            self.set_norm(norm)
+
+        if vmin is not None or vmax is not None:
+            self.set_clim(vmin, vmax)
+
+    def set_color(self, color):
+        if color is not None:
+            self.set_cmap(make_cmap(color))
+
+    def set_dpi(self, dpi):
+        self._dpi = dpi
+
+    def on_press(self, event=None):
+        try:
+            mode = self._ax.figure.canvas.toolbar.mode
+        except AttributeError:  # pragma: nocover
+            return
+        if mode != 'pan/zoom':
+            return
+        self._pressed = True
+        self.stale = True
+
+    def on_release(self, event=None):
+        self._pressed = False
+        self.stale = True
+
+    def get_extent(self):
+
+        if not self._update_while_panning and self._pressed:
+            return self._extent
+
+        xmin, xmax = self.axes.get_xlim()
+        ymin, ymax = self.axes.get_ylim()
+
+        self._extent = xmin, xmax, ymin, ymax
+
+        return self._extent
+
+    def get_transform(self):
+
+        # If we don't override this, the transform includes LogTransforms
+        # and the final image gets warped to be 'correct' in data space
+        # since Matplotlib 2.x:
+        #
+        #   https://matplotlib.org/users/prev_whats_new/whats_new_2.0.0.html#non-linear-scales-on-image-plots
+        #
+        # However, we want pixels to always visually be the same size, so we
+        # override the transform to not include the LogTransform components.
+
+        xmin, xmax = self._ax.get_xlim()
+        ymin, ymax = self._ax.get_ylim()
+
+        bbox = BboxTransformFrom(TransformedBbox(Bbox([[xmin, ymin], [xmax, ymax]]),
+                                                 IDENTITY))
+
+        return bbox + self._ax.transAxes
+
+    def make_image(self, *args, **kwargs):
+
+        if not self._update_while_panning and self._pressed:
+            return super(GenericDensityArtist, self).make_image(*args, **kwargs)
+
+        xmin, xmax = self._ax.get_xlim()
+        ymin, ymax = self._ax.get_ylim()
+
+        if self._dpi is None:
+            dpi = self.axes.figure.get_dpi()
+        else:
+            dpi = self._dpi
+
+        width = (self._ax.get_position().width *
+                 self._ax.figure.get_figwidth())
+        height = (self._ax.get_position().height *
+                  self._ax.figure.get_figheight())
+
+        nx = int(round(width * dpi))
+        ny = int(round(height * dpi))
+
+        flip_x = xmin > xmax
+        flip_y = ymin > ymax
+
+        if flip_x:
+            xmin, xmax = xmax, xmin
+
+        if flip_y:
+            ymin, ymax = ymax, ymin
+
+        bins = (ny, nx)
+
+        array = self._histogram2d_func(bins=bins, range=((ymin, ymax), (xmin, xmax)))
+
+        if flip_x or flip_y:
+            if flip_x and flip_y:
+                array = array[::-1, ::-1]
+            elif flip_x:
+                array = array[:, ::-1]
+            else:
+                array = array[::-1, :]
+
+        if self.origin == 'upper':
+            array = np.flipud(array)
+
+        if callable(self._density_vmin):
+            vmin = self._density_vmin(array)
+        else:
+            vmin = self._density_vmin
+
+        if callable(self._density_vmax):
+            vmax = self._density_vmax(array)
+        else:
+            vmax = self._density_vmax
+
+        self.set_data(array)
+        super(GenericDensityArtist, self).set_clim(vmin, vmax)
+
+        return super(GenericDensityArtist, self).make_image(*args, **kwargs)
+
+    def set_clim(self, vmin, vmax):
+        self._density_vmin = vmin
+        self._density_vmax = vmax
+
+    def set_norm(self, norm):
+        if norm.vmin is not None:
+            self._density_vmin = norm.vmin
+        if norm.vmax is not None:
+            self._density_vmax = norm.vmax
+        super(GenericDensityArtist, self).set_norm(norm)

--- a/mpl_scatter_density/scatter_density_artist.py
+++ b/mpl_scatter_density/scatter_density_artist.py
@@ -59,18 +59,18 @@ class ScatterDensityArtist(AxesImage):
         optionally be functions that take the density array and returns a single
         value (e.g. a function that returns the 5% percentile, or the minimum).
         This is useful since when zooming in/out, the optimal limits change.
-    histogram2d_callable : func, optional
+    update_while_panning : bool, optional
+        Whether to compute histograms on-the-fly while panning.
+    histogram2d_func : func, optional
         The function to use for computing the 2D histogram - this should have
         an API compatible with Numpy's :func:`~numpy.histogram2d` function.
-    compute_on_pan : bool, optional
-        Whether to compute histograms on-the-fly while panning.
     kwargs
         Any additional keyword arguments are passed to AxesImage.
     """
 
     def __init__(self, ax, x, y, dpi=72, downres_factor=4, color=None, c=None,
-                 vmin=None, vmax=None, norm=None, histogram2d_callable=None,
-                 compute_on_pan=True, **kwargs):
+                 vmin=None, vmax=None, norm=None, histogram2d_func=None,
+                 update_while_panning=True, **kwargs):
 
         super(ScatterDensityArtist, self).__init__(ax, **kwargs)
 
@@ -86,8 +86,8 @@ class ScatterDensityArtist(AxesImage):
         if downres_factor < 1 or downres_factor % 1 != 0:
             raise ValueError('downres_factor should be a strictly positive integer value')
 
-        self.compute_on_pan = compute_on_pan
-        self.histogram2d = histogram2d_callable or histogram2d
+        self.update_while_panning = update_while_panning
+        self.histogram2d = histogram2d_func or histogram2d
 
         self._downres_factor = downres_factor
         self.set_dpi(dpi)
@@ -164,7 +164,7 @@ class ScatterDensityArtist(AxesImage):
 
     def get_extent(self):
 
-        if not self.compute_on_pan and self._downres:
+        if not self.update_while_panning and self._downres:
             return self._extent
 
         xmin, xmax = self.axes.get_xlim()
@@ -195,7 +195,7 @@ class ScatterDensityArtist(AxesImage):
 
     def make_image(self, *args, **kwargs):
 
-        if not self.compute_on_pan and self._downres:
+        if not self.update_while_panning and self._downres:
             return super(ScatterDensityArtist, self).make_image(*args, **kwargs)
 
         xmin, xmax = self._ax.get_xlim()

--- a/mpl_scatter_density/scatter_density_artist.py
+++ b/mpl_scatter_density/scatter_density_artist.py
@@ -1,24 +1,12 @@
 from __future__ import division, print_function
 
-from math import log10
-
-import numpy as np
-
-from matplotlib.image import AxesImage
-from matplotlib.transforms import (IdentityTransform, TransformedBbox,
-                                   BboxTransformFrom, Bbox)
-
-from fast_histogram import histogram2d
-
-from .color import make_cmap
+from .generic_density_artist import GenericDensityArtist
+from .fixed_data_density_helper import FixedDataDensityHelper
 
 __all__ = ['ScatterDensityArtist']
 
-EMPTY_IMAGE = np.array([[np.nan]])
-IDENTITY = IdentityTransform()
 
-
-class ScatterDensityArtist(AxesImage):
+class ScatterDensityArtist(GenericDensityArtist):
     """
     Matplotlib artist to make a density plot of (x, y) scatter data.
 
@@ -61,261 +49,26 @@ class ScatterDensityArtist(AxesImage):
         This is useful since when zooming in/out, the optimal limits change.
     update_while_panning : bool, optional
         Whether to compute histograms on-the-fly while panning.
-    histogram2d_func : func, optional
-        The function to use for computing the 2D histogram - this should have
-        an API compatible with Numpy's :func:`~numpy.histogram2d` function.
     kwargs
         Any additional keyword arguments are passed to AxesImage.
     """
 
-    def __init__(self, ax, x, y, dpi=72, downres_factor=4, color=None, c=None,
-                 vmin=None, vmax=None, norm=None, histogram2d_func=None,
-                 update_while_panning=True, **kwargs):
-
-        super(ScatterDensityArtist, self).__init__(ax, **kwargs)
-
-        self._c = None
-        self._downres = False
-        self._density_vmin = np.nanmin
-        self._density_vmax = np.nanmax
-
-        self._ax = ax
-        self._ax.figure.canvas.mpl_connect('button_press_event', self.downres)
-        self._ax.figure.canvas.mpl_connect('button_release_event', self.upres)
-
-        if downres_factor < 1 or downres_factor % 1 != 0:
-            raise ValueError('downres_factor should be a strictly positive integer value')
-
-        self.update_while_panning = update_while_panning
-        self.histogram2d = histogram2d_func or histogram2d
-
-        self._downres_factor = downres_factor
-        self.set_dpi(dpi)
-        self.set_xy(x, y)
-        self.set_c(c)
-
-        self.upres()
-        self.set_array(EMPTY_IMAGE)
-
-        if color is not None:
-            self.set_color(color)
-
-        if norm is not None:
-            self.set_norm(norm)
-
-        if vmin is not None or vmax is not None:
-            self.set_clim(vmin, vmax)
-
-    def set_color(self, color):
-        if color is not None:
-            self.set_cmap(make_cmap(color))
+    def __init__(self, ax, x, y, downres_factor=4, c=None, **kwargs):
+        self.histogram2d_helper = FixedDataDensityHelper(ax, x, y, c=c, downres_factor=downres_factor)
+        super(ScatterDensityArtist, self).__init__(ax, histogram2d_func=self.histogram2d_helper, **kwargs)
 
     def set_xy(self, x, y):
-        self._x = x
-        self._y = y
-        self._x_log = None
-        self._y_log = None
-        self._x_log_sub = None
-        self._y_log_sub = None
-        step = self._downres_factor ** 2
-        self._x_sub = self._x[::step]
-        self._y_sub = self._y[::step]
+        self.histogram2d_helper.set_xy(x, y)
 
     def set_c(self, c):
-        self._c = c
-        step = self._downres_factor ** 2
-        if self._c is None:
-            self._c_sub = None
-        else:
-            self._c_sub = self._c[::step]
+        self.histogram2d_helper.set_c(c)
 
-    def set_dpi(self, dpi):
-        self._dpi = dpi
-
-    def _update_x_log(self):
-        step = self._downres_factor ** 2
-        with np.errstate(invalid='ignore'):
-            self._x_log = np.log10(self._x)
-        self._x_log_sub = self._x_log[::step]
-
-    def _update_y_log(self):
-        step = self._downres_factor ** 2
-        with np.errstate(invalid='ignore'):
-            self._y_log = np.log10(self._y)
-        self._y_log_sub = self._y_log[::step]
-
-    def downres(self, event=None):
-        if self._downres_factor == 1:
+    def on_press(self, event=None):
+        if self._update_while_panning and self.histogram2d_helper._downres_factor == 1:
             return
-        try:
-            mode = self._ax.figure.canvas.toolbar.mode
-        except AttributeError:  # pragma: nocover
-            return
-        if mode != 'pan/zoom':
-            return
-        self._downres = True
-        self.stale = True
+        self.histogram2d_helper.downres()
+        return super(ScatterDensityArtist, self).on_press()
 
-    def upres(self, event=None):
-        if self._downres_factor == 1:
-            return
-        self._downres = False
-        self.stale = True
-
-    def get_extent(self):
-
-        if not self.update_while_panning and self._downres:
-            return self._extent
-
-        xmin, xmax = self.axes.get_xlim()
-        ymin, ymax = self.axes.get_ylim()
-
-        self._extent = xmin, xmax, ymin, ymax
-
-        return self._extent
-
-    def get_transform(self):
-
-        # If we don't override this, the transform includes LogTransforms
-        # and the final image gets warped to be 'correct' in data space
-        # since Matplotlib 2.x:
-        #
-        #   https://matplotlib.org/users/prev_whats_new/whats_new_2.0.0.html#non-linear-scales-on-image-plots
-        #
-        # However, we want pixels to always visually be the same size, so we
-        # override the transform to not include the LogTransform components.
-
-        xmin, xmax = self._ax.get_xlim()
-        ymin, ymax = self._ax.get_ylim()
-
-        bbox = BboxTransformFrom(TransformedBbox(Bbox([[xmin, ymin], [xmax, ymax]]),
-                                                 IDENTITY))
-
-        return bbox + self._ax.transAxes
-
-    def make_image(self, *args, **kwargs):
-
-        if not self.update_while_panning and self._downres:
-            return super(ScatterDensityArtist, self).make_image(*args, **kwargs)
-
-        xmin, xmax = self._ax.get_xlim()
-        ymin, ymax = self._ax.get_ylim()
-
-        xscale = self._ax.get_xscale()
-        yscale = self._ax.get_yscale()
-
-        if self._dpi is None:
-            dpi = self.axes.figure.get_dpi()
-        else:
-            dpi = self._dpi
-
-        width = (self._ax.get_position().width *
-                 self._ax.figure.get_figwidth())
-        height = (self._ax.get_position().height *
-                  self._ax.figure.get_figheight())
-
-        nx = int(round(width * dpi))
-        ny = int(round(height * dpi))
-
-        flip_x = xmin > xmax
-        flip_y = ymin > ymax
-
-        if flip_x:
-            xmin, xmax = xmax, xmin
-
-        if flip_y:
-            ymin, ymax = ymax, ymin
-
-        if xscale == 'log':
-            xmin, xmax = log10(xmin), log10(xmax)
-            if self._x_log is None:
-                # We do this here insead of in set_xy to save time since in
-                # set_xy we don't know yet if the axes will be log or not.
-                self._update_x_log()
-            if self._downres:
-                x = self._x_log_sub
-            else:
-                x = self._x_log
-        elif xscale == 'linear':
-            if self._downres:
-                x = self._x_sub
-            else:
-                x = self._x
-        else:  # pragma: nocover
-            raise ValueError('Unexpected xscale: {0}'.format(xscale))
-
-        if yscale == 'log':
-            ymin, ymax = log10(ymin), log10(ymax)
-            if self._y_log is None:
-                # We do this here insead of in set_xy to save time since in
-                # set_xy we don't know yet if the axes will be log or not.
-                self._update_y_log()
-            if self._downres:
-                y = self._y_log_sub
-            else:
-                y = self._y_log
-        elif yscale == 'linear':
-            if self._downres:
-                y = self._y_sub
-            else:
-                y = self._y
-        else:  # pragma: nocover
-            raise ValueError('Unexpected xscale: {0}'.format(xscale))
-
-        if self._downres:
-            nx_sub = nx // self._downres_factor
-            ny_sub = ny // self._downres_factor
-            bins = (ny_sub, nx_sub)
-            weights = self._c_sub
-        else:
-            bins = (ny, nx)
-            weights = self._c
-
-        if weights is None:
-            array = self.histogram2d(y, x, bins=bins, weights=weights,
-                                     range=((ymin, ymax), (xmin, xmax)))
-        else:
-            array = self.histogram2d(y, x, bins=bins, weights=weights,
-                                     range=((ymin, ymax), (xmin, xmax)))
-            count = self.histogram2d(y, x, bins=bins,
-                                     range=((ymin, ymax), (xmin, xmax)))
-
-            with np.errstate(invalid='ignore'):
-                array /= count
-
-        if flip_x or flip_y:
-            if flip_x and flip_y:
-                array = array[::-1, ::-1]
-            elif flip_x:
-                array = array[:, ::-1]
-            else:
-                array = array[::-1, :]
-
-        if self.origin == 'upper':
-            array = np.flipud(array)
-
-        if callable(self._density_vmin):
-            vmin = self._density_vmin(array)
-        else:
-            vmin = self._density_vmin
-
-        if callable(self._density_vmax):
-            vmax = self._density_vmax(array)
-        else:
-            vmax = self._density_vmax
-
-        self.set_data(array)
-        super(ScatterDensityArtist, self).set_clim(vmin, vmax)
-
-        return super(ScatterDensityArtist, self).make_image(*args, **kwargs)
-
-    def set_clim(self, vmin, vmax):
-        self._density_vmin = vmin
-        self._density_vmax = vmax
-
-    def set_norm(self, norm):
-        if norm.vmin is not None:
-            self._density_vmin = norm.vmin
-        if norm.vmax is not None:
-            self._density_vmax = norm.vmax
-        super(ScatterDensityArtist, self).set_norm(norm)
+    def on_release(self, event=None):
+        self.histogram2d_helper.upres()
+        return super(ScatterDensityArtist, self).on_release()

--- a/mpl_scatter_density/tests/test_scatter_density_artist.py
+++ b/mpl_scatter_density/tests/test_scatter_density_artist.py
@@ -31,6 +31,9 @@ class TestScatterDensity(object):
         self.fig = plt.figure(figsize=(3, 3))
         self.ax = self.fig.add_axes([0.13, 0.13, 0.8, 0.8])
 
+    def teardown_method(self, method):
+        plt.close(self.fig)
+
     @pytest.mark.mpl_image_compare(style={}, baseline_dir=baseline_dir)
     def test_default(self):
         a = ScatterDensityArtist(self.ax, self.x1, self.y1)
@@ -90,7 +93,7 @@ class TestScatterDensity(object):
         self.ax.add_artist(a)
         self.ax.figure.canvas.toolbar = MagicMock()
         self.ax.figure.canvas.toolbar.mode = 'pan/zoom'
-        a.downres()
+        a.on_press()
         self.ax.set_xlim(0.1, 3.)
         self.ax.set_ylim(0.1, 3.)
         if log:
@@ -134,7 +137,7 @@ class TestScatterDensity(object):
         self.ax.set_ylim(-6.5, 6.5)
         self.ax.figure.canvas.toolbar = MagicMock()
         self.ax.figure.canvas.toolbar.mode = 'pan/zoom'
-        a.downres()
+        a.on_press()
         return self.fig
 
     @pytest.mark.mpl_image_compare(style={}, baseline_dir=baseline_dir)
@@ -200,7 +203,7 @@ class TestScatterDensity(object):
         # draw when calling figure.canvas.draw()
         self.ax.figure.savefig(tmpdir.join('test1.png').strpath)
         assert not a.stale
-        a.downres()
+        a.on_press()
         assert a.stale
 
         a = ScatterDensityArtist(self.ax, self.x1, self.y1, downres_factor=1)
@@ -211,7 +214,7 @@ class TestScatterDensity(object):
         # draw when calling figure.canvas.draw()
         self.ax.figure.savefig(tmpdir.join('test2.png').strpath)
         assert not a.stale
-        a.downres()
+        a.on_press()
         assert not a.stale
 
     def test_default_dpi(self, tmpdir):
@@ -238,5 +241,5 @@ class TestScatterDensity(object):
         # draw when calling figure.canvas.draw()
         self.ax.figure.savefig(tmpdir.join('test.png').strpath)
         assert not a.stale
-        a.downres()
+        a.on_press()
         assert not a.stale

--- a/mpl_scatter_density/tests/test_scatter_density_axes.py
+++ b/mpl_scatter_density/tests/test_scatter_density_axes.py
@@ -21,6 +21,9 @@ class TestScatterDensityAxes(object):
     def setup_method(self, method):
         self.fig = plt.figure(figsize=(3, 3))
 
+    def teardown_method(self, method):
+        plt.close(self.fig)
+
     @pytest.mark.mpl_image_compare(style={}, baseline_dir=baseline_dir)
     def test_axes_basic(self):
         self.ax = ScatterDensityAxes(self.fig, [0.15, 0.15, 0.8, 0.8])


### PR DESCRIPTION
Add ``compute_on_pan`` to control whether to compute histograms even when panning, and ``histogram2d_callable`` to override the default fast-histogram computation.