### PR TITLE
Improve check for resize support to not trigger Qt and Tk imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,6 @@
 ----------------
 
 - Avoid unecessary imports of Qt and Tk. [#27]
-No changes yet.
 
 0.5 (2019-01-27)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.6 (unreleased)
 ----------------
 
-- No changes yet.
+- Avoid unecessary imports of Qt and Tk. [#27]
+No changes yet.
 
 0.5 (2019-01-27)
 ----------------

--- a/mpl_scatter_density/tests/test_base_image_artist.py
+++ b/mpl_scatter_density/tests/test_base_image_artist.py
@@ -1,0 +1,28 @@
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTk
+from matplotlib.backends.backend_qt5 import FigureCanvasQT
+
+from ..base_image_artist import supports_resize
+
+
+def test_supports_resize():
+
+    canvas = FigureCanvasAgg(Figure())
+    assert not supports_resize(canvas)
+
+    canvas = FigureCanvasTk(Figure())
+    assert supports_resize(canvas)
+
+    canvas = FigureCanvasQT(Figure())
+    assert supports_resize(canvas)
+
+    class SubclassA(FigureCanvasAgg):
+        pass
+    canvas = SubclassA(Figure())
+    assert not supports_resize(canvas)
+
+    class SubclassB(FigureCanvasQT):
+        pass
+    canvas = SubclassB(Figure())
+    assert supports_resize(canvas)

--- a/mpl_scatter_density/tests/test_base_image_artist.py
+++ b/mpl_scatter_density/tests/test_base_image_artist.py
@@ -1,7 +1,14 @@
+import pytest
+
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.backends.backend_tkagg import FigureCanvasTk
-from matplotlib.backends.backend_qt5 import FigureCanvasQT
+
+try:
+    from matplotlib.backends.backend_qt5 import FigureCanvasQT
+except ImportError:
+    QT_INSTALLED = False
+else:
+    QT_INSTALLED = True
 
 from ..base_image_artist import supports_resize
 
@@ -11,16 +18,17 @@ def test_supports_resize():
     canvas = FigureCanvasAgg(Figure())
     assert not supports_resize(canvas)
 
-    canvas = FigureCanvasTk(Figure())
-    assert supports_resize(canvas)
-
-    canvas = FigureCanvasQT(Figure())
-    assert supports_resize(canvas)
-
     class SubclassA(FigureCanvasAgg):
         pass
     canvas = SubclassA(Figure())
     assert not supports_resize(canvas)
+
+
+@pytest.mark.skipif('not QT_INSTALLED')
+def test_supports_resize_qt():
+
+    canvas = FigureCanvasQT(Figure())
+    assert supports_resize(canvas)
 
     class SubclassB(FigureCanvasQT):
         pass


### PR DESCRIPTION
This is to make sure we never import Qt or Tk if working in e.g. a Jupyter environment.