### PR TITLE
DEP: drop undeclared runtime dependency on `setuptools`

### DIFF
--- a/mpl_scatter_density/__init__.py
+++ b/mpl_scatter_density/__init__.py
@@ -1,9 +1,11 @@
 from .scatter_density_artist import *  # noqa
 from .scatter_density_axes import *  # noqa
 
-from pkg_resources import get_distribution, DistributionNotFound
+import sys
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
-try:
-    __version__ = get_distribution('mpl-scatter-density').version
-except DistributionNotFound:
-    __version__ = 'undefined'
+__version__ = version("mpl-scatter-density")
+del version, sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     numpy
     matplotlib>=3.0
     fast-histogram>=0.3
+    importlib_metadata>=1.4 ; python_version < '3.8'
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Discovered while trying to remove `setuptools` as a dependency in `glue-core`
Note that the problem is evident when testing `mpl-scatter-density` in a fresh env that doesn't have setuptools, e.g., using `uv venv`


```
uv venv
uv pip install -e .
source .venv/bin/activate
python -c "import mpl_scatter_density"
```
```python-traceback
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/clm/dev/astropy-project/deps/mpl-scatter-density/mpl_scatter_density/__init__.py", line 4, in <module>
    from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'
```